### PR TITLE
chore: make it easy to find the repository/source from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@farbenmeer/eager",
   "version": "0.1.0",
   "description": "",
+  "repository": "https://github.com/farbenmeer/eager",
   "main": "dist/index.js",
   "type": "module",
   "files": [


### PR DESCRIPTION
When looking at the npm project page there is no easy way to find the source code.
This should fix this and make a link to the source code available on the npm project page.